### PR TITLE
Rename proof of presence device activation token

### DIFF
--- a/doc/model.er
+++ b/doc/model.er
@@ -61,7 +61,7 @@ name {label: "String, unique"}
 +device_type_id {label: "Integer"}
 +building_id {label: "Integer, null"}
 
-proof_of_presence_id {label: "String, unique"}
+device_activation_token {label: "String, unique"}
 session_token {label: "String, null"}
 
 created_on {label: "Timestamp"}

--- a/src/api.py
+++ b/src/api.py
@@ -130,14 +130,14 @@ def account_activate(activation_token: AccountActivate):
 def account_device_activate(device_verify: DeviceVerify,
                             authorization: HTTPAuthorizationCredentials = Depends(account_auth)):
 
-    proof_of_presence_id = device_verify.proof_of_presence_id
+    device_activation_token = device_verify.device_activation_token
     account_session_token = authorization.credentials
 
     account = crud.account_by_session(db.session, account_session_token)
     if not account:
         return http_status(Unauthorized, 'Invalid account session token')
 
-    device = crud.device_by_pop(db.session, proof_of_presence_id)
+    device = crud.device_by_activation_token(db.session, device_activation_token)
     if not device:
         return http_status(NotFound, 'No device found for provided proof-of-presence id')
     if device.activated_on:
@@ -161,7 +161,7 @@ def device_create(device_input: DeviceCreate,
                   authorization: HTTPAuthorizationCredentials = Depends(admin_auth)):
     name = device_input.name
     device_type_name = device_input.device_type
-    proof_of_presence_id = device_input.proof_of_presence_id
+    device_activation_token = device_input.device_activation_token
     admin_session_token = authorization.credentials
 
     admin = get_admin(admin_session_token)
@@ -172,10 +172,10 @@ def device_create(device_input: DeviceCreate,
     if not device_type:
         return http_status(BadRequest, f'Unknown device type "{device_type_name}"')
 
-    if crud.device_by_pop(db.session, proof_of_presence_id):
+    if crud.device_by_activation_token(db.session, device_activation_token):
         return http_status(BadRequest, 'Proof-of-presence identifier already in use')
 
-    device = crud.device_create(db.session, device_type, proof_of_presence_id)
+    device = crud.device_create(db.session, device_type, device_activation_token)
     return device
 
 
@@ -203,7 +203,7 @@ def device_read(device_name: str,
 
     timestamp = crud.device_latest_measurement_timestamp(db.session, device_name)
     device.latest_measurement_timestamp = timestamp
-    
+
     display_name = crud.device_display_name(db.session, device_name)
     device.display_name = display_name
     
@@ -220,9 +220,9 @@ def device_read(device_name: str,
 )
 def device_activate(device_verify: DeviceVerify):
 
-    proof_of_presence_id = device_verify.proof_of_presence_id
+    device_activation_token = device_verify.device_activation_token
 
-    device = crud.device_by_pop(db.session, proof_of_presence_id)
+    device = crud.device_by_activation_token(db.session, device_activation_token)
     if not device:
         return http_status(NotFound, 'No device found for provided proof-of-presence id')
     if not device.building_id:

--- a/src/crud.py
+++ b/src/crud.py
@@ -154,13 +154,13 @@ def device_type_by_name(db: Session, name: str) -> Optional[DeviceType]:
     return db.query(DeviceType).filter(DeviceType.name == name).one_or_none()
 
 
-def device_create(db: Session, device_type: DeviceType, proof_of_presence_id: str) -> Device:
+def device_create(db: Session, device_type: DeviceType, device_activation_token: str) -> Device:
     """
     Create a new Device
     """
     device = Device(
         device_type=device_type,
-        proof_of_presence_id=proof_of_presence_id,
+        device_activation_token=device_activation_token,
         created_on=datetime.now(timezone.utc),
     )
 
@@ -171,11 +171,11 @@ def device_create(db: Session, device_type: DeviceType, proof_of_presence_id: st
     return device
 
 
-def device_by_pop(db: Session, proof_of_presence_id: str) -> Optional[Device]:
+def device_by_pop(db: Session, device_activation_token: str) -> Optional[Device]:
     """
     Get Device instance by proof-of-presence identifier
     """
-    query = db.query(Device).filter(Device.proof_of_presence_id == proof_of_presence_id)
+    query = db.query(Device).filter(Device.device_activation_token == device_activation_token)
     return query.one_or_none()
 
 

--- a/src/model.py
+++ b/src/model.py
@@ -188,7 +188,7 @@ class Device(Base):
         nullable=True
     )
 
-    proof_of_presence_id = Column(
+    device_activation_token = Column(
         Text,
         unique=True,
         comment='Unique, random token to identify the device during activation'

--- a/src/schema.py
+++ b/src/schema.py
@@ -70,11 +70,11 @@ class DeviceSession(SessionToken):
 
 class DeviceCreate(BaseModel):
     device_type: str
-    proof_of_presence_id: constr(strip_whitespace=True, min_length=8, max_length=1024)
+    device_activation_token: constr(strip_whitespace=True, min_length=8, max_length=1024)
 
 
 class DeviceVerify(BaseModel):
-    proof_of_presence_id: constr(strip_whitespace=True, min_length=8, max_length=1024)
+    device_activation_token: constr(strip_whitespace=True, min_length=8, max_length=1024)
 
 
 class DeviceTypeItem(BaseModel):
@@ -124,7 +124,7 @@ class DeviceItemMeasurementTime(DeviceItem):
 class DeviceCompleteItem(BaseModel):
     id: int
     device_type: DeviceTypeCompleteItem
-    proof_of_presence_id: str
+    device_activation_token: str
     created_on: Datetime
     activated_on: Optional[Datetime]
 


### PR DESCRIPTION
This breaking API change implements the server-side changes of https://trello.com/c/ZtHJzJEB/79-consider-renaming-proofofpresenceid-in-database-and-api-to-deviceactivationtoken; definitely requires review and should only be published live well coordinated with changes in app software and firmware that adhere to the breaking API change. 

That is, very likely only AFTER Winnovation on Friday June 4, 2021