### PR TITLE
Device name may include hex digits

### DIFF
--- a/src/schema.py
+++ b/src/schema.py
@@ -83,7 +83,7 @@ class DeviceSession(SessionToken):
 
 
 class DeviceCreate(BaseModel):
-    name: constr(regex=r'TWOMES-([0-9a-fA-F]){6}')
+    name: constr(regex=r'TWOMES-([0-9A-F]){6}')
     device_type: str
     activation_token: constr(strip_whitespace=True, min_length=8, max_length=1024)
 


### PR DESCRIPTION
added both lowercase a-f as well as uppercase A-F (preferred) to regex that checks device name