### PR TITLE
property and device updates related to presence and CO2 meter

### DIFF
--- a/src/data/sensors.csv
+++ b/src/data/sensors.csv
@@ -34,8 +34,6 @@ OpenThermGW-Nodo,OpenTherm gateway Nodo,relativeModulationLevel,%
 OpenThermGW-Nodo,OpenTherm gateway Nodo,isCentralHeatingModeOn,
 OpenThermGW-Nodo,OpenTherm gateway Nodo,isDomesticHotWaterModeOn,
 OpenThermGW-Nodo,OpenTherm gateway Nodo,roomSetpointTemp,°C
-OpenThermGW-Nodo,OpenTherm gateway Nodo,listRSSI,[dBm]
-OpenThermGW-Nodo,OpenTherm gateway Nodo,listHomePresence,
 OpenThermGW-DIYLESS,OpenTherm gateway DIYLESS,heartbeat,
 OpenThermGW-DIYLESS,OpenTherm gateway DIYLESS,roomTemp,°C
 OpenThermGW-DIYLESS,OpenTherm gateway DIYLESS,boilerSupplyTemp,°C


### PR DESCRIPTION
- remove isHome and RSSI, 
  *This requires pruning the database with an SQL statement first!* 
- add listHomePresence and listRSSI;
- add device types DSMR-P1-gateway-CO2; DSMR-P1-gateway-TinTsTrCO2