### PR TITLE
Add `new_fw` and `booted_fw` measurement values

### DIFF
--- a/src/data/sensors.csv
+++ b/src/data/sensors.csv
@@ -74,6 +74,8 @@ Presence-Detector,Aanwezigheidsdetector,heartbeat,
 Presence-Detector,Aanwezigheidsdetector,listRSSI,[dBm]
 Presence-Detector,Aanwezigheidsdetector,listHomePresence,
 Generic-Test,Testmeetapparaatje,heartbeat,
+Generic-Test,Testmeetapparaatje,new_fw,
+Generic-Test,Testmeetapparaatje,booted_fw,
 DSMR-P1-gateway-TinTsTrCO2,Slimme meter monitor met cv-ketelmodule en kamermodule met CO₂-sensor,heartbeat,
 DSMR-P1-gateway-TinTsTrCO2,Slimme meter monitor met cv-ketelmodule en kamermodule met CO₂-sensor,eMeterReadingSupplyLow,kWh
 DSMR-P1-gateway-TinTsTrCO2,Slimme meter monitor met cv-ketelmodule en kamermodule met CO₂-sensor,eMeterReadingSupplyHigh,kWh


### PR DESCRIPTION
These changes make it possible for logging `new_fw` and `booted_fw` while performing OTA firmware updates.

## Test results

### Property table
![image](https://user-images.githubusercontent.com/43145188/167789933-7aad5cc7-6cf6-41ce-89be-f8385d62e72a.png)

### Database entries of new_fw (and heartbeat)
Sending `booted_fw` was not implemented in Twomes at the time of testing, but works exactly the same.

![image](https://user-images.githubusercontent.com/43145188/167790108-fac4d417-74f3-4b66-9961-6e4ab933bfcb.png)

### Logs
```
INFO:     192.168.10.203:55554 - "POST /device/measurements/variable-interval HTTP/1.1" 200 OK
DEBUG:db:140328507660096: session create
DEBUG:db:140328507660096: session close
INFO:     192.168.10.203:55558 - "POST /device/measurements/variable-interval HTTP/1.1" 200 OK
DEBUG:db:140328507660096: session create
DEBUG:db:140328507660096: session close
INFO:     192.168.10.203:55560 - "POST /device/measurements/variable-interval HTTP/1.1" 200 OK
DEBUG:db:140328507660096: session create
DEBUG:db:140328507660096: session close
INFO:     192.168.10.203:55562 - "POST /device/measurements/variable-interval HTTP/1.1" 200 OK
DEBUG:db:140328507660096: session create
DEBUG:db:140328507660096: session close
INFO:     192.168.10.203:55564 - "POST /device/measurements/variable-interval HTTP/1.1" 200 OK
DEBUG:db:140328507660096: session create
DEBUG:db:140328507660096: session close
INFO:     192.168.10.203:55566 - "POST /device/measurements/variable-interval HTTP/1.1" 200 OK
DEBUG:db:140328507660096: session create
DEBUG:db:140328507660096: session close
```