### PR TITLE
Add twomes-boiler-base-firmware and properties

### DIFF
--- a/src/data/sensors.csv
+++ b/src/data/sensors.csv
@@ -117,3 +117,21 @@ DSMR-P1-gateway-TinCO2,Slimme meter monitor met kamermodule met CO₂-sensor,rel
 DSMR-P1-gateway-TinCO2,Slimme meter monitor met kamermodule met CO₂-sensor,listRSSI,[dBm]
 DSMR-P1-gateway-TinCO2,Slimme meter monitor met kamermodule met CO₂-sensor,listHomePresence,
 OpenTherm-Monitor,OpenTherm monitor,boilerMaxSupplyTemp,°C
+twomes-boiler-base-firmware,cv-ketelmodule,heartbeat,
+twomes-boiler-base-firmware,cv-ketelmodule,roomTemp,°C
+twomes-boiler-base-firmware,cv-ketelmodule,roomSetpointTemp,°C
+twomes-boiler-base-firmware,cv-ketelmodule,boilerReturnTemp,°C
+twomes-boiler-base-firmware,cv-ketelmodule,boilerSupplyTemp,°C
+twomes-boiler-base-firmware,cv-ketelmodule,boilerMaxSupplyTemp,°C
+twomes-boiler-base-firmware,cv-ketelmodule,isBoilerFlameOn,
+twomes-boiler-base-firmware,cv-ketelmodule,isCentralHeatingModeOn,
+twomes-boiler-base-firmware,cv-ketelmodule,isDomesticHotWaterModeOn,
+twomes-boiler-base-firmware,cv-ketelmodule,maxBoilerCap,kW
+twomes-boiler-base-firmware,cv-ketelmodule,maxModulationLevel,%
+twomes-boiler-base-firmware,cv-ketelmodule,minModulationLevel,%
+twomes-boiler-base-firmware,cv-ketelmodule,relativeModulationLevel,%
+twomes-boiler-base-firmware,cv-ketelmodule,boilerTemp1,°C
+twomes-boiler-base-firmware,cv-ketelmodule,boilerTemp2,°C
+twomes-boiler-base-firmware,cv-ketelmodule,booted_fw,
+twomes-boiler-base-firmware,cv-ketelmodule,new_fw,
+twomes-boiler-base-firmware,cv-ketelmodule,batteryVoltage,


### PR DESCRIPTION
Several properties were added for a new device type 'twomes-boiler-base-firmware'.
Firmware that will use this: https://github.com/energietransitie/twomes-boiler-base-firmware.

The properties are based on this conversation (in dutch):
> Er moet idd een nieuw type worden aangemaakt.
> mij lijkt nu het beste:
> `twomes-boiler-base-firmware`
>
> en qua properties de optelsom (zonder dubbelingen) van OpenTherm-Monitor, minus property `countPresence`, plus met properties `boilerTemp1` en `boilerTemp2`, `booted_fw`, `new_fw`. Eigenlijk vind ik property `batteryVoltage` ook overbodig, maar dat is waarschijnlijk niet makkelijk
>
> Gebruik als DeviceType.displayname maar: `cv-ketelmodule`