### PR TITLE
Add `/account/me` API endpoint

### DIFF
--- a/src/api.py
+++ b/src/api.py
@@ -64,6 +64,24 @@ def http_status(http_status_class: Type[HttpStatus], message: str) -> JSONRespon
     return JSONResponse(status_code=http_status_class.code, content={'detail': message})
 
 
+@app.get(
+    '/account/me',
+    response_model=AccountSession,
+    responses={
+        Unauthorized.code: {'model': Unauthorized},
+    }
+)
+def me(authorization: HTTPAuthorizationCredentials = Depends(account_auth)):
+    account_session_token = authorization.credentials
+    account = crud.account_by_session(db.session, account_session_token)
+
+    if not account:
+        return http_status(Unauthorized, 'Invalid account session token')
+
+    return AccountSession(
+        session_token=account_session_token,
+    )
+
 @app.post(
     '/account',
     response_model=AccountItem,


### PR DESCRIPTION
This pull request adds a new endpoint `/account/me` to the API. The endpoint is designed to validate session tokens in the Need for Heat application.

The endpoint is implemented as a GET request and requires authentication using a session token. Upon successful authentication, the endpoint returns a JSON object containing the provided session token so no information of the account is being exposed.