### PR TITLE
fix: publish container on push to main

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,6 +2,8 @@ name: Docker publish
 
 on:
   push:
+    branches:
+      - main
     tags:
       - "v*.*.*"
 


### PR DESCRIPTION
Docker image did not build and publish on push to main because of an error I made in the GH actions file.