### PR TITLE
fix: write content-type header

### DIFF
--- a/handlers/handler.go
+++ b/handlers/handler.go
@@ -73,6 +73,8 @@ type Handler func(http.ResponseWriter, *http.Request) error
 
 // Implement the http.Handler interface.
 func (fn Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+
 	err := fn(w, r)
 	if err != nil {
 		if handlerErr, ok := err.(*HandlerError); ok {


### PR DESCRIPTION
Previously, the content-type header was no set explicitly. now, we set it to application/json.