### PR TITLE
fix: check if array length before accessing

### DIFF
--- a/handlers/authorization.go
+++ b/handlers/authorization.go
@@ -36,8 +36,12 @@ func (h *AuthorizationHandler) Middleware(kind twomes.AuthKind) func(next Handle
 				return NewHandlerError(nil, "unauthorized", http.StatusUnauthorized).WithMessage("authorization header not present")
 			}
 
-			authHeader = strings.Split(authHeader, "Bearer ")[1]
+			splitHeader := strings.Split(authHeader, "Bearer ")
+			if len(splitHeader) != 2 {
+				return NewHandlerError(nil, "unauthorized", http.StatusUnauthorized).WithMessage("authorization malformed")
+			}
 
+			authHeader = splitHeader[1]
 			if authHeader == "" {
 				return NewHandlerError(nil, "unauthorized", http.StatusUnauthorized).WithMessage("authorization malformed")
 			}


### PR DESCRIPTION
If the array did not have a lenght of 2 and we access position 1, the program would panic. This is now fixed.