### PR TITLE
fix: Redirect using traefik stripped prefix

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -151,9 +151,10 @@ func setupSwaggerDocs(r *chi.Mux, baseURL string) {
 		logrus.Fatal(err)
 	}
 
-	r.Method("GET", "/openapi.yml", handlers.Handler(docsHandler.OpenAPISpec))                  // Serve openapi.yml
-	r.Method("GET", "/docs", http.RedirectHandler("/docs/", http.StatusMovedPermanently))       // Serve /docs
-	r.Method("GET", "/docs/*", http.StripPrefix("/docs/", http.FileServer(http.FS(swaggerUI)))) // Serve static files.
+	r.Method("GET", "/openapi.yml", handlers.Handler(docsHandler.OpenAPISpec))                        // Serve openapi.yml
+	r.Method("GET", "/docs/*", http.StripPrefix("/docs/", http.FileServer(http.FS(swaggerUI))))       // Serve static files.
+	r.Method("GET", "/docs", handlers.Handler(docsHandler.RedirectDocs(http.StatusMovedPermanently))) // Redirect /docs to /docs/
+	r.Method("GET", "/", handlers.Handler(docsHandler.RedirectDocs(http.StatusSeeOther)))             // Redirect / to /docs/
 }
 
 func setupAdminRPCHandler(adminHandler *handlers.AdminHandler) {

--- a/handlers/docs.go
+++ b/handlers/docs.go
@@ -31,7 +31,7 @@ func NewDocsHandler(files fs.FS, baseURL string) (*DocsHandler, error) {
 	}, nil
 }
 
-// Hanlde API endpoint for displaying OpenAPI spec.
+// Handle API endpoint for displaying OpenAPI spec.
 // This file should be displayed as openapi.yml.
 func (h *DocsHandler) OpenAPISpec(w http.ResponseWriter, r *http.Request) error {
 	err := h.template.Execute(w, h.baseURL)
@@ -40,4 +40,18 @@ func (h *DocsHandler) OpenAPISpec(w http.ResponseWriter, r *http.Request) error 
 	}
 
 	return nil
+}
+
+// Handle redirection from /docs to /docs/ to serve static files.
+func (h *DocsHandler) RedirectDocs(redirectCode int) func(http.ResponseWriter, *http.Request) error {
+	return func(w http.ResponseWriter, r *http.Request) error {
+		redirectURL := "/docs/"
+
+		// Fix prefix stripped by Traefik proxy to ensure correcy redirection.
+		redirectURL = r.Header.Get("X-Forwarded-Prefix") + redirectURL
+
+		http.Redirect(w, r, redirectURL, redirectCode)
+
+		return nil
+	}
 }


### PR DESCRIPTION
The redirection failed when using traefik to serve this API on /v2 and then stripping it.
The call to /v2/docs would be redirected to /docs/, which are the v1 docs. (no /v1 or /v2 is fallback to /v1)