### PR TITLE
feat: implement new device name standard

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,3 +203,4 @@ We use and gratefully aknowlegde the efforts of the makers of the following sour
 * [logrus](https://github.com/sirupsen/logrus), by Simon Eskildsen, licensed under [MIT license](https://github.com/sirupsen/logrus/blob/master/LICENSE)
 * [golang-jwt/jwt](https://github.com/golang-jwt/jwt), by Dave Grijalva, licensed under [MIT license](https://github.com/golang-jwt/jwt/blob/main/LICENSE)
 * [swagger-ui](https://github.com/swagger-api/swagger-ui), swagger-api, licensed under [Apache 2.0 license](https://github.com/swagger-api/swagger-ui/blob/master/LICENSE)
+* [crc16](https://github.com/sigurn/crc16), by sigurn, licensed under [MIT license](https://github.com/sigurn/crc16/blob/master/LICENSE)

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/mattn/go-isatty v0.0.18 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
+	github.com/sigurn/crc16 v0.0.0-20211026045750-20ab5afb07e3 // indirect
 	github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 // indirect
 	golang.org/x/sys v0.7.0 // indirect
 	modernc.org/libc v1.22.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -31,6 +31,8 @@ github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/sigurn/crc16 v0.0.0-20211026045750-20ab5afb07e3 h1:aQKxg3+2p+IFXXg97McgDGT5zcMrQoi0EICZs8Pgchs=
+github.com/sigurn/crc16 v0.0.0-20211026045750-20ab5afb07e3/go.mod h1:9/etS5gpQq9BJsJMWg1wpLbfuSnkm8dPF6FdW2JXVhA=
 github.com/sirupsen/logrus v1.9.0 h1:trlNQbNUG3OdDrDil03MCb1H2o9nJ1x4/5LYw7byDE0=
 github.com/sirupsen/logrus v1.9.0/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/handlers/device.go
+++ b/handlers/device.go
@@ -42,7 +42,7 @@ func (h *DeviceHandler) Create(w http.ResponseWriter, r *http.Request) error {
 		return NewHandlerError(err, "wrong token kind", http.StatusForbidden).WithMessage("wrong token kind was used")
 	}
 
-	device, err := h.service.Create(request.Name, request.DeviceType, request.BuildingID, auth.ID, request.ActivationSecret)
+	device, err := h.service.Create(request.Name, request.BuildingID, auth.ID, request.ActivationSecret)
 	if err != nil {
 		if helpers.IsMySQLRecordNotFoundError(err) {
 			return NewHandlerError(err, "not found", http.StatusNotFound)
@@ -53,6 +53,10 @@ func (h *DeviceHandler) Create(w http.ResponseWriter, r *http.Request) error {
 		}
 
 		if errors.Is(err, services.ErrBuildingDoesNotBelongToAccount) {
+			return NewHandlerError(err, err.Error(), http.StatusBadRequest)
+		}
+
+		if errors.Is(err, services.ErrHashDoesNotMatchType) {
 			return NewHandlerError(err, err.Error(), http.StatusBadRequest)
 		}
 

--- a/ports/device.go
+++ b/ports/device.go
@@ -15,7 +15,7 @@ type DeviceRepository interface {
 
 // DeviceService exposes all operations that can be performed on a [twomes.Device].
 type DeviceService interface {
-	Create(name string, deviceType twomes.DeviceType, building, accountID uint, activationSecret string) (twomes.Device, error)
+	Create(name string, buildingID, accountID uint, activationSecret string) (twomes.Device, error)
 	GetByID(id uint) (twomes.Device, error)
 	GetByName(name string) (twomes.Device, error)
 	Activate(name, activationSecret string) (twomes.Device, error)

--- a/ports/devicetype.go
+++ b/ports/devicetype.go
@@ -14,6 +14,7 @@ type DeviceTypeRepository interface {
 type DeviceTypeService interface {
 	Create(name, installationManualURL, infoURL string) (twomes.DeviceType, error)
 	Find(deviceType twomes.DeviceType) (twomes.DeviceType, error)
+	GetByHash(deviceTypeHash string) (twomes.DeviceType, error)
 	GetByID(id uint) (twomes.DeviceType, error)
 	GetByName(name string) (twomes.DeviceType, error)
 }

--- a/services/devicetype.go
+++ b/services/devicetype.go
@@ -1,8 +1,17 @@
 package services
 
 import (
+	"errors"
+	"fmt"
+
 	"github.com/energietransitie/twomes-backoffice-api/ports"
 	"github.com/energietransitie/twomes-backoffice-api/twomes"
+	"github.com/sigurn/crc16"
+	"github.com/sirupsen/logrus"
+)
+
+var (
+	ErrHashDoesNotMatchType = errors.New("hash does not match a device type")
 )
 
 type DeviceTypeService struct {
@@ -10,23 +19,47 @@ type DeviceTypeService struct {
 
 	// Service used when creating a device type.
 	propertyService ports.PropertyService
+
+	// Hashed device types.
+	hashedDeviceTypes map[string]string
 }
 
 // Create a new DeviceTypeService.
 func NewDeviceTypeService(repository ports.DeviceTypeRepository, propertyService ports.PropertyService) *DeviceTypeService {
-	return &DeviceTypeService{
+	deviceTypeService := &DeviceTypeService{
 		repository:      repository,
 		propertyService: propertyService,
 	}
+
+	deviceTypeService.updateDeviceTypeHashes()
+
+	return deviceTypeService
 }
 
 func (s *DeviceTypeService) Create(name, installationManualURL, infoURL string) (twomes.DeviceType, error) {
 	deviceType := twomes.MakeDeviceType(name, installationManualURL, infoURL)
-	return s.repository.Create(deviceType)
+
+	deviceType, err := s.repository.Create(deviceType)
+	if err != nil {
+		return deviceType, err
+	}
+
+	s.updateDeviceTypeHashes()
+
+	return deviceType, nil
 }
 
 func (s *DeviceTypeService) Find(deviceType twomes.DeviceType) (twomes.DeviceType, error) {
 	return s.repository.Find(deviceType)
+}
+
+func (s *DeviceTypeService) GetByHash(deviceTypeHash string) (twomes.DeviceType, error) {
+	name, ok := s.hashedDeviceTypes[deviceTypeHash]
+	if !ok {
+		return twomes.DeviceType{}, ErrHashDoesNotMatchType
+	}
+
+	return s.repository.Find(twomes.DeviceType{Name: name})
 }
 
 func (s *DeviceTypeService) GetByID(id uint) (twomes.DeviceType, error) {
@@ -35,4 +68,22 @@ func (s *DeviceTypeService) GetByID(id uint) (twomes.DeviceType, error) {
 
 func (s *DeviceTypeService) GetByName(name string) (twomes.DeviceType, error) {
 	return s.repository.Find(twomes.DeviceType{Name: name})
+}
+
+// Update the map of hashes to device types.
+func (s *DeviceTypeService) updateDeviceTypeHashes() {
+	deviceTypes, err := s.repository.GetAll()
+	if err != nil {
+		logrus.Warn(err)
+		return
+	}
+
+	s.hashedDeviceTypes = make(map[string]string)
+
+	table := crc16.MakeTable(crc16.CRC16_XMODEM)
+
+	for _, deviceType := range deviceTypes {
+		hash := crc16.Checksum([]byte(deviceType.Name), table)
+		s.hashedDeviceTypes[fmt.Sprintf("%X", hash)] = deviceType.Name
+	}
 }

--- a/swaggerdocs/openapi.template.yml
+++ b/swaggerdocs/openapi.template.yml
@@ -359,13 +359,7 @@ paths:
               properties:
                 name:
                   type: string
-                  example: TWOMES-AC4BC3
-                device_type:
-                  type: object
-                  properties:
-                    name:
-                      type: string
-                      example: Generic-Test
+                  example: FCA2-AC4BC3
                 building_id:
                   type: integer
                   example: 1
@@ -524,7 +518,7 @@ paths:
               properties:
                 name:
                   type: string
-                  example: TWOMES-AC4BC3
+                  example: FCA2-AC4BC3
       responses:
         "200":
           description: OK
@@ -810,7 +804,7 @@ components:
           example: 1
         name:
           type: string
-          example: TWOMES-AC4BC3
+          example: FCA2-AC4BC3
         device_type:
           $ref: "#/components/schemas/DeviceType"
         building_id:
@@ -836,7 +830,7 @@ components:
           example: 1
         name:
           type: string
-          example: TWOMES-AC4BC3
+          example: FCA2-AC4BC3
         device_type:
           $ref: "#/components/schemas/DeviceType"
         building_id:
@@ -866,7 +860,7 @@ components:
           example: 1
         name:
           type: string
-          example: TWOMES-AC4BC3
+          example: FCA2-AC4BC3
         device_type:
           $ref: "#/components/schemas/DeviceType"
         building_id:


### PR DESCRIPTION
This new implementation uses the following device names: <4 digit hash of device type name>-<last 6 digits of MAC>

The POST /device endpoint uses the name to infer the type from the hash.