### PR TITLE
Revert "chore: rename longtitude to longitude"

### DIFF
--- a/handlers/account.go
+++ b/handlers/account.go
@@ -70,7 +70,7 @@ func (h *AccountHandler) Activate(w http.ResponseWriter, r *http.Request) error 
 		return NewHandlerError(err, "wrong token kind", http.StatusForbidden).WithMessage("wrong token kind was used")
 	}
 
-	account, err := h.accountService.Activate(auth.ID, request.Longitude, request.Latitude, request.TZName)
+	account, err := h.accountService.Activate(auth.ID, request.Longtitude, request.Latitude, request.TZName)
 	if err != nil {
 		if errors.Is(err, twomes.ErrAccountAlreadyActivated) {
 			return NewHandlerError(err, "account already activated", http.StatusBadRequest)

--- a/ports/account.go
+++ b/ports/account.go
@@ -15,7 +15,7 @@ type AccountRepository interface {
 // An AccountService exposes all operations we can perform on a [twomes.Account]
 type AccountService interface {
 	Create(campaign twomes.Campaign) (twomes.Account, error)
-	Activate(id uint, longitude, latitude float32, tzName string) (twomes.Account, error)
+	Activate(id uint, longtitude, latitude float32, tzName string) (twomes.Account, error)
 	GetByID(id uint) (twomes.Account, error)
 	GetCloudFeedAuthStatuses(id uint) ([]twomes.CloudFeedAuthStatus, error)
 }

--- a/repositories/building.go
+++ b/repositories/building.go
@@ -19,7 +19,7 @@ func NewBuildingRepository(db *gorm.DB) *BuildingRepository {
 type BuildingModel struct {
 	gorm.Model
 	AccountModelID uint `gorm:"column:account_id"`
-	Longitude      float32
+	Longtitude     float32
 	Latitude       float32
 	TZName         string
 	Devices        []DeviceModel
@@ -41,7 +41,7 @@ func MakeBuildingModel(building twomes.Building) BuildingModel {
 	return BuildingModel{
 		Model:          gorm.Model{ID: building.ID},
 		AccountModelID: building.AccountID,
-		Longitude:      building.Longitude,
+		Longtitude:     building.Longtitude,
 		Latitude:       building.Latitude,
 		TZName:         building.TZName,
 		Devices:        deviceModels,
@@ -58,12 +58,12 @@ func (m *BuildingModel) fromModel() twomes.Building {
 	}
 
 	return twomes.Building{
-		ID:        m.Model.ID,
-		AccountID: m.AccountModelID,
-		Longitude: m.Longitude,
-		Latitude:  m.Latitude,
-		TZName:    m.TZName,
-		Devices:   devices,
+		ID:         m.Model.ID,
+		AccountID:  m.AccountModelID,
+		Longtitude: m.Longtitude,
+		Latitude:   m.Latitude,
+		TZName:     m.TZName,
+		Devices:    devices,
 	}
 }
 

--- a/services/account.go
+++ b/services/account.go
@@ -77,7 +77,7 @@ func (s *AccountService) Create(campaign twomes.Campaign) (twomes.Account, error
 }
 
 // Activate an account.
-func (s *AccountService) Activate(id uint, longitude, latitude float32, tzName string) (twomes.Account, error) {
+func (s *AccountService) Activate(id uint, longtitude, latitude float32, tzName string) (twomes.Account, error) {
 	account, err := s.repository.Find(twomes.Account{ID: id})
 	if err != nil {
 		return twomes.Account{}, err
@@ -94,7 +94,7 @@ func (s *AccountService) Activate(id uint, longitude, latitude float32, tzName s
 	}
 
 	if len(account.Buildings) < 1 {
-		building, err := s.buildingService.Create(account.ID, longitude, latitude, tzName)
+		building, err := s.buildingService.Create(account.ID, longtitude, latitude, tzName)
 		if err != nil {
 			return twomes.Account{}, err
 		}

--- a/twomes/building.go
+++ b/twomes/building.go
@@ -2,21 +2,21 @@ package twomes
 
 // A Building belongs to a research subject where we take regular measurements with devices.
 type Building struct {
-	ID        uint      `json:"id"`
-	AccountID uint      `json:"account_id"`
-	Longitude float32   `json:"longitude"`
-	Latitude  float32   `json:"latitude"`
-	TZName    string    `json:"tz_name"`
-	Devices   []*Device `json:"devices,omitempty"`
+	ID         uint      `json:"id"`
+	AccountID  uint      `json:"account_id"`
+	Longtitude float32   `json:"longtitude"`
+	Latitude   float32   `json:"latitude"`
+	TZName     string    `json:"tz_name"`
+	Devices    []*Device `json:"devices,omitempty"`
 }
 
 // Create a new Building.
 func MakeBuilding(accountID uint, long, lat float32, tzName string) Building {
 	return Building{
-		AccountID: accountID,
-		Longitude: long,
-		Latitude:  lat,
-		TZName:    tzName,
+		AccountID:  accountID,
+		Longtitude: long,
+		Latitude:   lat,
+		TZName:     tzName,
 	}
 }
 


### PR DESCRIPTION
This reverts commit cda2f2b59b0699273f20ee7e80a834d1ff8d06fb.

The commit fixed the spelling of `longtitude` to `longitude`. But because our app does not have this change implemented yet, this caused issues. Reverting for now.