### PR TITLE
fix: allow re-authentication for cloud feeds

### DIFF
--- a/services/cloudfeedauth.go
+++ b/services/cloudfeedauth.go
@@ -66,11 +66,14 @@ func (s *CloudFeedAuthService) Create(ctx context.Context, accountID, cloudFeedI
 	cloudFeedAuth := twomes.MakeCloudFeedAuth(accountID, cloudFeedID, accessToken, refreshToken, expiry, authGrantToken)
 
 	cloudFeedAuth, err = s.cloudFeedAuthRepo.Create(cloudFeedAuth)
+	if err != nil {
+		return cloudFeedAuth, err
+	}
 
 	// Signal an update
 	s.updateChan <- struct{}{}
 
-	return cloudFeedAuth, err
+	return cloudFeedAuth, nil
 }
 
 // Find a cloudFeedAuth using any field set in the cloudFeedAuth struct.


### PR DESCRIPTION
If a cloud feed auth cannot be refreshed, it is soft deleted.
The soft deletion blocked creation of a new auth record, and thus re-authentication.

This is fixed now, by first checking if a soft-deleted records exists, and then deleting it before creating a new one.