### PR TITLE
fix: use correct latest_upload for GET /building/{id} endpoint

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -104,7 +104,7 @@ func main() {
 	cloudFeedAuthService := services.NewCloudFeedAuthService(cloudFeedAuthRepository, cloudFeedRepository)
 	campaignService := services.NewCampaignService(campaignRepository, appService, cloudFeedService)
 	propertyService := services.NewPropertyService(propertyRepository)
-	uploadService := services.NewUploadService(uploadRepository, propertyService)
+	uploadService := services.NewUploadService(uploadRepository, deviceRepository, propertyService)
 	buildingService := services.NewBuildingService(buildingRepository, uploadService)
 	accountService := services.NewAccountService(accountRepository, authService, appService, campaignService, buildingService, cloudFeedAuthService)
 	deviceTypeService := services.NewDeviceTypeService(deviceTypeRepository, propertyService)

--- a/services/device.go
+++ b/services/device.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/energietransitie/twomes-backoffice-api/internal/helpers"
 	"github.com/energietransitie/twomes-backoffice-api/ports"
 	"github.com/energietransitie/twomes-backoffice-api/twomes"
 )
@@ -79,15 +78,6 @@ func (s *DeviceService) GetByName(name string) (twomes.Device, error) {
 	device.LatestUpload, err = s.uploadService.GetLatestUploadTimeForDeviceWithID(device.ID)
 	if err != nil {
 		return twomes.Device{}, err
-	}
-
-	// If the device corresponds to a cloud_feed_auth and there was no upload yet,
-	// use the cloud_feed_auth's created_at_time.
-	if device.LatestUpload == nil {
-		device.LatestUpload, err = s.repository.FindCloudFeedAuthCreationTimeFromDeviceID(device.ID)
-		if err != nil && !helpers.IsMySQLRecordNotFoundError(err) {
-			return twomes.Device{}, err
-		}
 	}
 
 	return device, nil


### PR DESCRIPTION
The GET /building/{id} endpoint would not consider an cloud_feed_auth's creation date as a latest_upload before this change.