### PR TITLE
ci: speed up container build

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -18,10 +18,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      # Setup QEMU to support multiple platforms
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-
       # Setup Docker buildx
       - name: Set up Docker buildx
         id: buildx

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
-FROM golang:1.20 as build
+FROM --platform=$BUILDPLATFORM golang:1.20 as build
+
+ARG GOOS=$TARGETOS
+ARG GOARCH=$TARGETARCH
 
 WORKDIR /go/src/twomes-api-server
 


### PR DESCRIPTION
The build was too slow. I have had a lot of times where is need the new image immediately, but I have to wait 10 minutes. This change takes the build time from approximately 10 minutes, to about 1 minute or less.