### PR TITLE
fix: ignore an 'null' timestamp value.

### DIFF
--- a/services/cloudfeeds/enelogic/enelogic.go
+++ b/services/cloudfeeds/enelogic/enelogic.go
@@ -30,7 +30,6 @@ var client = &http.Client{
 }
 
 const (
-	baseURL                    = "https://enelogic.com/api"
 	endpointMeasuringPoints    = "/measuringpoints"
 	endpointDatapointsMonths   = "/measuringpoints/{{.MeasuringPointID}}/datapoint/months/{{.From}}/{{.To}}"
 	endpointDatapointsDays     = "/measuringpoints/{{.MeasuringPointID}}/datapoint/days/{{.From}}/{{.To}}"
@@ -43,6 +42,8 @@ const (
 )
 
 var (
+	baseURL = "https://enelogic.com/api"
+
 	ErrNoData = errors.New("no data from enelogic")
 )
 
@@ -165,29 +166,9 @@ func (q *Quantity) UnmarshalJSON(b []byte) error {
 type MeasuringsPointsResponse []MeasuringPoint
 
 type MeasuringPoint struct {
-	Timezone string       `json:"timezone"`
-	ID       int          `json:"id"`
-	UnitType UnitType     `json:"unitType"`
-	DayMin   EnelogicTime `json:"dayMin"`
-	DayMax   EnelogicTime `json:"dayMax"`
-	MonthMin EnelogicTime `json:"monthMin"`
-	MonthMax EnelogicTime `json:"monthMax"`
-	YearMin  EnelogicTime `json:"yearMin"`
-	YearMax  EnelogicTime `json:"yearMax"`
-	Active   bool         `json:"active"`
-}
-
-func (m *MeasuringPoint) UnmarshalJSON(b []byte) error {
-	// Set all EnelogicTime fields' LocationName to the timezone of the measuring point using a pointer.
-	m.DayMin.LocationName = &m.Timezone
-	m.DayMax.LocationName = &m.Timezone
-	m.MonthMin.LocationName = &m.Timezone
-	m.MonthMax.LocationName = &m.Timezone
-	m.YearMin.LocationName = &m.Timezone
-	m.YearMax.LocationName = &m.Timezone
-
-	type localMeasuringPoint *MeasuringPoint
-	return json.Unmarshal(b, localMeasuringPoint(m))
+	Timezone string   `json:"timezone"`
+	ID       int      `json:"id"`
+	UnitType UnitType `json:"unitType"`
 }
 
 type DatapointsResponse []DataPoint

--- a/services/cloudfeeds/enelogic/enelogic_test.go
+++ b/services/cloudfeeds/enelogic/enelogic_test.go
@@ -1,9 +1,36 @@
 package enelogic
 
 import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
+
+	"github.com/go-chi/chi/v5"
 )
+
+// setupTestServer starts a mocked Enelogic API server and changes the baseURL to make
+// all requests go to the mocked API.
+//
+// Call the teardown function that is returned when you are done.
+func setupTestServer(t *testing.T, defineRoutesFn func(r *chi.Mux)) func() {
+	t.Helper()
+
+	r := chi.NewMux()
+
+	defineRoutesFn(r)
+
+	server := httptest.NewServer(r)
+	originalURL := baseURL
+	baseURL = server.URL
+
+	return func() {
+		baseURL = originalURL
+		server.Close()
+	}
+}
 
 func TestSplitDays_multipleDays(t *testing.T) {
 	from, err := time.Parse(time.RFC3339, "2023-12-15T12:57:24Z")
@@ -109,5 +136,30 @@ func TestSplitDays_singeDay(t *testing.T) {
 	want = "2023-12-16"
 	if got.String() != want {
 		t.Errorf("splitDays(from=2023-12-15, to=2023-12-16) End = %s; want %s", got, want)
+	}
+}
+
+func TestGetMeasuringPoints(t *testing.T) {
+	teardown := setupTestServer(t, func(r *chi.Mux) {
+		// Emulate /measuringpoints API endpoint
+		r.Get(endpointMeasuringPoints, func(w http.ResponseWriter, r *http.Request) {
+			data := `[{
+				"timezone": "Europe/Amsterdam",
+				"id": 1,
+				"unitType": 1,
+				"dayMin": null
+			}]`
+
+			data = strings.ReplaceAll(data, "\n", "")
+			data = strings.ReplaceAll(data, "\t", "")
+
+			w.Write([]byte(data))
+		})
+	})
+	defer teardown()
+
+	_, err := getMeasuringPoints(context.Background(), "token")
+	if err != nil {
+		t.Fatalf("getMeasuringPoints() err = %v", err)
 	}
 }


### PR DESCRIPTION
Previously, this would cause termination of further data retrievel, even if there could actually be data available.

A test case was also added to make sure this works, and that the same does not happen again.